### PR TITLE
Add greenkeeper to monitor dependency updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Google OAuth 2 with access control for Node Express app
 
+[![Greenkeeper badge](https://badges.greenkeeper.io/pihvi/express-gauth.svg)](https://greenkeeper.io/)
+
 ### Installation
 
 This is a [Node.js](https://nodejs.org/en/) module available through the

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "express": "4.15.4",
     "express-session": "1.15.5"
   },
+  "scripts": {
+    "test": "echo TODO: tests"
+  },
   "directories": {
     "example": "examples"
   }


### PR DESCRIPTION
Had to add dummy Travis build to enable this. Also work now only on my account as don't wanna let these outsiders (Travis, Greenkeeper) to Reaktor GitHub account..