### PR TITLE
Make authentication authorization scopes configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ gauth({
   clientDomain: 'http://localhost:5555',
   allowedDomains: ['reaktor.fi', 'reaktor.com'], // User needs to login with Google and email with these domains.
   allowedEmails: ['john@example.com', 'jussi@example.com'], // These users are allowed login through Google auth.
+  authorizationScopes: ['profile', 'email'], // Which authorization scopes the authentication authorizes
   publicEndPoints: ['/logout'], // These end points do not require any authentication.
   clientExpressApp: app,
   unauthorizedUser: (req, res, next, user) => res.send(`<h1>Sorry ${user.displayName}, you has no access!</h1>`),

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = function expressGAuth(options) {
     allowedDomains: [],
     allowedEmails: [],
     publicEndPoints: [],
+    authorizationScopes: ['profile', 'email'],
     logger: console,
     unauthorizedUser: (req, res, next, user) => res.send(`<h1>Login error, user not valid!</h1><h2>${user.displayName} ${JSON.stringify(user.emails)}</h2>`),
     errorPassportAuth: (req, res, next, err) => res.send('<h1>Error logging in!</h1>'),
@@ -42,7 +43,7 @@ module.exports = function expressGAuth(options) {
             } else {
               passport.authenticate('google',
                 {
-                  scope: ['profile', 'email'],
+                  scope: config.authorizationScopes,
                   prompt: 'select_account'
                 },
                 function passportAuthCb(err, user, info) {


### PR DESCRIPTION
Some applications may need other authorization scopes if they use the same auth to access other google resources, like for example google calendar data.