### PR TITLE
Inject authorization token & expiry date to returned profile

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ module.exports = function expressGAuth(options) {
       clientID: config.clientID,
       clientSecret: config.clientSecret,
       callbackURL: config.clientDomain
-    }, function(accessToken, refreshToken, profile, cb) {
+    }, function(accessToken, refreshToken, params, profile, cb) {
+      profile.credentials = params; // inject authorization info (tokens, token type, expires_in) to profile
       cb(null, profile, accessToken, refreshToken)
     }
   ))


### PR DESCRIPTION
Some projects might need the authorization data (access_token, token_type and expires_in fields etc) if they use those tokens to access other google resources, like calendar data