### PR TITLE
Allow overriding google authorization params

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ app.listen(5555, function() {
 ``` 
 
 #### All config options
+
 ``` javascript
 gauth({
   clientID: process.env.GOOGLE_CLIENT_ID,
@@ -82,6 +83,14 @@ gauth({
     error: function() {
       console.log('myerror', new Date, JSON.stringify(arguments))
     }
+  },
+  // Override default authorization params
+  // List of supported params are available in passport-google-oauth2 source
+  // https://github.com/jaredhanson/passport-google-oauth2/blob/master/lib/strategy.js
+  // https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters
+  googleAuthorizationParams: {
+    scope: ['profile', 'email'],
+    hostedDomain: 'reaktor.fi'
   }
 })
 ``` 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ module.exports = function expressGAuth(options) {
     errorNoUser: (req, res, next) => res.send('<h1>Error logging in, no user!</h1>'),
     errorLogin: (req, res, next, err) => res.send('<h1>Login error!</h1>'),
     serializeUser: (user, done) => done(null, user),
-    deserializeUser: (user, done) => done(null, user)
+    deserializeUser: (user, done) => done(null, user),
+    googleAuthorizationParams: {
+      scope: ['profile', 'email'],
+      prompt: 'select_account'
+    }
   }
   const config = Object.assign(defaults, options)
 
@@ -41,10 +45,7 @@ module.exports = function expressGAuth(options) {
               next()
             } else {
               passport.authenticate('google',
-                {
-                  scope: ['profile', 'email'],
-                  prompt: 'select_account'
-                },
+                config.googleAuthorizationParams,
                 function passportAuthCb(err, user, info) {
                   if (err) {
                     config.logger.error('GAuth error', err)


### PR DESCRIPTION
`prompt: 'select_account'` does not seem to be an optimal default in every case. Omitting `prompt` and setting `hostedDomain` allows more user-friendly login in case only one domain is allowed.

> `prompt`
>
> Optional*. A space-delimited, case-sensitive list of prompts to present the user. **If you don’t specify this parameter, the user will be prompted only the first time your app requests access.** Possible values are: `none`, `consent`, `select_account`