### PR TITLE
Disallow setting returnTo if internal or asset request

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ gauth({
   // Time in seconds to refresh access token before it expires
   refreshBefore: 10
   // Redirect user to the original url
-  returnToOriginalUrl: false
+  returnToOriginalUrl: false,
+  // originalUrl will be set as the return url only if returnToOriginalUrl is true,
+  // and the originalUrl passes this predicate
+  isReturnUrlAllowed: url => /\.(css|jpe?g|gif|ico|js|json|png|svg|woff2?)$/i.test(url) === false,
 })
 ```
 [Full example](examples/all_configs_express.js)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ gauth({
 
 ### Version history
 
+* 2.5.0 - Make it possible to disallow return urls when using returnToOriginalUrl
+* 2.4.0 - Use refresh token to refresh expiring access tokens
 * 2.4.0 - Use refresh token to refresh expiring access tokens
 * 2.3.0 - Add option for redirecting user to original url
 * 2.2.0 - Add profile.credentials which contains user's authorization tokens

--- a/examples/all_configs_express.js
+++ b/examples/all_configs_express.js
@@ -25,7 +25,20 @@ const myGauth = gauth({
     error: function() {
       console.log('myerror', new Date, JSON.stringify(arguments))
     }
-  }
+  },
+  // Override default authorization params
+  // List of supported params are available in passport-google-oauth2 source
+  // https://github.com/jaredhanson/passport-google-oauth2/blob/master/lib/strategy.js
+  // https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters
+  googleAuthorizationParams: {
+    scope: ['profile', 'email'],
+    hostedDomain: 'reaktor.fi'
+  },
+  // Redirect user to the original url
+  returnToOriginalUrl: false,
+  // originalUrl will be set as the return url only if returnToOriginalUrl is true,
+  // and the originalUrl passes this predicate
+  isReturnUrlAllowed: url => /\.(css|jpe?g|gif|ico|js|json|png|svg|woff2?)$/i.test(url) === false,
 })
 
 // Session must be initialized first

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reaktor/express-gauth",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reaktor/express-gauth",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Simplified GAuth login for Express with ACLs",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Resolves #10.

Currently some of Reaktor's internal applications fixes the 'redirect to asset' bug in gauth in their own code base. But if we use the `returnToOriginalUrl` option that was introduced in #8, there is no way to go around it.

This PR makes it so that returnTo is not set if 
A: url matches `disallowedReturnToUrlRegex`
B: returnTo is already set once
C: request is an internal request