### PR TITLE
Change to a named export and add typescript typings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# Check out https://editorconfig.org for more info
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,35 @@
+import { RequestHandler, Request, Response, NextFunction } from 'express';
+
+export function expressGAuth(options: GauthOptions): RequestHandler;
+
+export interface GauthOptions {
+  readonly clientID: string;
+  readonly clientSecret: string;
+  readonly clientDomain: string;
+
+  readonly allowedDomains?: ReadonlyArray<string>;
+  readonly allowedEmails?: ReadonlyArray<string>;
+  readonly publicEndPoints?: ReadonlyArray<string>;
+  readonly logger?: { log: (output: string) => void, error: (output: string) => void };
+  readonly unauthorizedUser?: (req: Request, res: Response, next: NextFunction, user: unknown) => void;
+  readonly errorPassportAuth?: (req: Request, res: Response, next: NextFunction, err) => void;
+  readonly errorNoUser?: (req: Request, res: Response, next: NextFunction) => void;
+  readonly errorLogin?: (req: Request, res: Response, next: NextFunction, err: unknown) => void;
+  readonly serializeUser?: (user: unknown, done: DoneCallback<unknown>) => void;
+  readonly deserializeUser?: (user: unknown, done: DoneCallback<unknown>) => void;
+  readonly returnToOriginalUrl?: boolean;
+  readonly isReturnUrlAllowed?: (url: string) => boolean;
+  readonly googleAuthorizationParams?: {
+    readonly scope?: ReadonlyArray<string>;
+    readonly prompt?: 'none' | 'consent' | 'select_account';
+    readonly accessType?: 'offline' | 'online';
+    readonly hostedDomain?: string;
+    readonly loginHint?: string;
+    readonly includeGrantedScopes?: boolean;
+  },
+  readonly refreshBefore?: number;
+}
+
+export type DoneCallback<T> =
+  | ((err: unknown) => void)
+  | ((err: null, value: T) => void);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const addSeconds = require('date-fns/add_seconds')
 const passport = require('passport')
 const url = require("url")
 
-module.exports = function expressGAuth(options) {
+module.exports.expressGAuth = function expressGAuth(options) {
   const GoogleStrategy = require('passport-google-oauth20').Strategy
   const refresh = require('passport-oauth2-refresh')
   const isAfter = require('date-fns/is_after')

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,74 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/body-parser": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
+      "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.1.tgz",
+      "integrity": "sha512-QgbIMRU1EVRry5cIu1ORCQP4flSYqLM1lS5LYyGWfKnFT3E58f0gKto7BR13clBFVrVZ0G0rbLZ1hUpSkgQQOA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
+      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -487,6 +555,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
+    },
+    "typescript": {
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "dev": true
     },
     "uid-safe": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reaktor/express-gauth",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reaktor/express-gauth",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Simplified GAuth login for Express with ACLs",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "passport-oauth2-refresh": "^1.1.0"
   },
   "devDependencies": {
+    "@types/express": "^4.16.1",
     "express": "^4.16.4",
-    "express-session": "^1.15.6"
+    "express-session": "^1.15.6",
+    "typescript": "^3.3.3333"
   },
   "scripts": {
     "test": "echo TODO: tests"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Simplified GAuth login for Express with ACLs",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/reaktor/express-gauth.git"


### PR DESCRIPTION
The main purpose of this PR is to add typings for typescript users.

However, to improve the usability with TS, I changed the export from a commonjs style default export to a named export.

This means that this is a BREAKING CHANGE.

Migration is simple though, instead of
```js
const expressGAuth = require('@reaktor/express-gauth');
// or
import expressGAuth from '@reaktor/express-gauth';
```
just import with a destructuring assignment:
```js
const { expressGAuth } = require('@reaktor/express-gauth');
// or
import { expressGAuth } from '@reaktor/express-gauth';
```